### PR TITLE
Add ${relativeFileDir} to settings variables

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -118,6 +118,9 @@ function resolvePath(path: string, associated: string): string {
         'fileDirname': parsedFilePath.dir,
         // the current opened file's extension
         'fileExtname': parsedFilePath.ext,
+        // the relative directory, so one can use it in settings as:
+        // "**/*.c": "${workspaceFolder}/.o/${relativeFileDir}/${fileBasenameNoExtension}.s"
+        'relativeFileDir': Path.relative(workspacePath, parsedFilePath.dir),
     };
 
     const variablesRe = /\$\{(.*?)\}/g;


### PR DESCRIPTION
Enables easy way to integrate extension when building deep tree of sources with -save-temps=obj
In example, when object files are stored in "./o" directory (followed by source sub directories) we can configure extensions with:
```
"settings": {
    "disasexpl.associations": {
        "**/*.c": "${workspaceFolder}/.o/${relativeFileDir}/${fileBasenameNoExtension}.s",
        "**/*.cpp": "${workspaceFolder}/.o/${relativeFileDir}/${fileBasenameNoExtension}.s"
    }	
}
```