### PR TITLE
Only check for basename instead of full filename

### DIFF
--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -83,7 +83,8 @@ export class AsmDecorator {
 
         // assembly may contain lines from different source files,
         // thus we should check that line comes from current opened file
-        if (asmLine.source.file === undefined || !sourceName.endsWith(asmLine.source.file)) {
+        var path = require("path");
+        if (asmLine.source.file === undefined || !sourceName.endsWith(path.basename(asmLine.source.file))) {
             return false;
         }
 


### PR DESCRIPTION
The relation between assembly and c/c++ code cannot be established if the debug file shows .file entries with relative paths.
For example: ".file 1 ./test.cpp".

Now, only the filename is checked in this sanity check, instead of the full .file entry.