### PR TITLE
Add suport for objdumped disassembly with visualize-jumps option

### DIFF
--- a/src/asm.ts
+++ b/src/asm.ts
@@ -137,7 +137,7 @@ export class AsmParser {
     cudaBeginDef = /\.(entry|func)\s+(?:\([^)]*\)\s*)?([$.A-Z_a-z][\w$.]*)\($/;
     cudaEndDef = /^\s*\)\s*$/;
 
-    asmOpcodeRe = /^\s*(?<address>[\da-f]+):\s*(?<opcodes>([\da-f]{2} ?)+)\s*(?<disasm>.*)/;
+    asmOpcodeRe = /^\s*(?<address>[\da-f]+):([|\\\/>X-]*\s*)*(?<opcodes>([\da-f]{2} ?)+)\s*(?<disasm>.*)/;
     lineRe = /^(\/[^:]+):(?<line>\d+).*/;
 
     // labelRe is made very greedy as it's also used with demangled objdump

--- a/src/asm.ts
+++ b/src/asm.ts
@@ -137,7 +137,7 @@ export class AsmParser {
     cudaBeginDef = /\.(entry|func)\s+(?:\([^)]*\)\s*)?([$.A-Z_a-z][\w$.]*)\($/;
     cudaEndDef = /^\s*\)\s*$/;
 
-    asmOpcodeRe = /^\s*(?<address>[\da-f]+):([|\\\/>X-]*\s*)*(?<opcodes>([\da-f]{2} ?)+)\s*(?<disasm>.*)/;
+    asmOpcodeRe = /^\s*(?<address>[\da-f]+):(?:[|\\\/>X+-]|\s)*(?<opcodes>([\da-f]{2} ?)+)\s*(?<disasm>.*)/;
     lineRe = /^(\/[^:]+):(?<line>\d+).*/;
 
     // labelRe is made very greedy as it's also used with demangled objdump


### PR DESCRIPTION
regex of `asmOpcodeRe` is updated so disassembly generated by objdump with `--visualize-jumps` could be also parsed.

Here's a disassembly I generate with `riscv64-linux-gnu-objdump build/bubble-sort-riscv64-nemu.elf -l --visualize-jumps=extended-color --disassemble=bubble_sort`

![image](https://user-images.githubusercontent.com/37630203/164868291-0fc6d349-23c7-4729-8f29-4548690eff1e.png)

> `--visualize-jumps` will visualize jumps by drawing these nice ASCII art lines 🤩