### PR TITLE
couple of additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Next, when you generated disassembly, you should tell the extension where to sea
 
 ```json
 "disasexpl.associations": {
-    "**/*.c": "${fileDirname}/${fileBasenameNoExtension}.S",
-    "**/*.cpp": "${fileDirname}/${fileBasenameNoExtension}.S"
+    "**/*.c": ["${fileDirname}/${fileBasenameNoExtension}.S"],
+    "**/*.cpp": ["${fileDirname}/${fileBasenameNoExtension}.S"]
 }
 ```
 Make sure to adjust the disassembly extension to `.s` when using the "-save-temps" option.

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
                     "disasexpl.associations": {
                         "type": "object",
                         "default": {
-                            "**/*.c": "${fileDirname}/${fileBasenameNoExtension}.S",
-                            "**/*.cpp": "${fileDirname}/${fileBasenameNoExtension}.S"
+                            "**/*.c": ["${fileDirname}/${fileBasenameNoExtension}.S"],
+                            "**/*.cpp": ["${fileDirname}/${fileBasenameNoExtension}.S"]
                         },
                         "description": "Where to search disassembly for matching source files",
                         "scope": "resource"

--- a/src/document.ts
+++ b/src/document.ts
@@ -19,17 +19,15 @@ export class AsmDocument {
         this._emitter = emitter;
 
         // Watch for underlying assembly file and reload it on change
+        workspace.onDidChangeTextDocument(e => { if (e.document.uri.path === this._uri.path) this.update(); });
+        workspace.onDidDeleteFiles(e => e.files.forEach(f => { if (uri.path.includes(f.path)) this.update(); }));
+
         this._watcher = workspace.createFileSystemWatcher(uri.path);
-        this._watcher.onDidChange(() => this.updateLater());
-        this._watcher.onDidCreate(() => this.updateLater());
-        this._watcher.onDidDelete(() => this.updateLater());
+        this._watcher.onDidChange(() => this.update());
+        this._watcher.onDidCreate(() => this.update());
+        this._watcher.onDidDelete(() => this.update());
 
         this.update();
-    }
-
-    private updateLater() {
-        // Workarond for https://github.com/Microsoft/vscode/issues/72831
-        setTimeout(() => this.update(), 100);
     }
 
     private update() {


### PR DESCRIPTION
the previous solution of delaying before calling update is inconsistent - with larger files or on specific filesystems, the file may not be released before the delay expires (I could reproduce this using WSL2).

There's no 'one size fits all' solution down this path, and adding a customisation option for the delay seems messy. Instead, I've added completion events for change/delete which avoid this issue.

-

I also added support for multiple associations per key - clang and gcc currently have different output formats when using -save-temps (one generates <filename>.ext.s, the other <filename>.s which required changes to the associations settings when switching between compilers.

Having an array of associations solves this problem, while also giving additional flexibility for those that want to take advantage of it. An alternative would be to support regular expressions or some other form of 'complex' matching